### PR TITLE
changed formula from SHA1 to SHA256

### DIFF
--- a/Formula/tldr.rb
+++ b/Formula/tldr.rb
@@ -4,7 +4,7 @@ class Tldr < Formula
   homepage "https://github.com/tldr-pages/tldr"
 
   url "https://github.com/tldr-pages/tldr-cpp-client/archive/v1.1.0.tar.gz"
-  sha1 "5223b86952e1d6c34f3cd4bf827f8723c8751af7"
+  sha256 "eed26fd5471963d63708e5142388d47f4619649070839dbfe1c46c7842975138"
 
   head "https://github.com/tldr-pages/tldr-cpp-client.git"
 


### PR DESCRIPTION
Per Homebrew's new guidelines:
> Warning: SHA1 support is deprecated and will be removed in a future version.
> Please switch this formula to SHA256.